### PR TITLE
Switch to using colon as creds delimiter

### DIFF
--- a/htgettoken
+++ b/htgettoken
@@ -354,7 +354,7 @@ def main():
                       help="path in vault for accessing oidc authentication")
     parser.add_option("--secretpath",
                       metavar="vaultpath",
-                      default="secret/oauth-%issuer/creds/%credkey-%role",
+                      default="secret/oauth-%issuer/creds/%credkey:%role",
                       help="path in vault for accessing bearer token secret")
     parser.add_option("-c", "--configdir",
                       metavar="path",


### PR DESCRIPTION
It's possible for credkey to have a hyphen in it, so colon is safer.