### PR TITLE
Add GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,183 @@
+name: Build and test
+
+on:
+  # run workflows on main master and release/** branches
+  push:
+    branches:
+      - main
+      - master
+      - release/**
+  # run workflows on pull requests against the same branches
+  pull_request:
+    branches:
+      - main
+      - master
+      - release/**
+
+# automatically cancel redundant builds
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # -- RPM builds --
+
+  # Build the Source RPM
+  rhel-srpm:
+    name: EL ${{ matrix.version }} (${{ matrix.distro }}) source package
+    strategy:
+      fail-fast: false
+      matrix:
+        # Build for CentOS 7, and Rockylinux >=8
+        include:
+          - distro: centos
+            version: 7
+          - distro: rockylinux
+            version: 8
+          - distro: rockylinux
+            version: 9
+    runs-on: ubuntu-latest
+    container: ${{ matrix.distro }}:${{ matrix.version }}
+    steps:
+      - name: Get source code
+        uses: actions/checkout@v2
+
+      - name: Configure SRPM build tools
+        run: |
+          yum -y install \
+              gcc \
+              make \
+              python-srpm-macros \
+              rpm-build \
+              yum-utils \
+          ;
+
+      # on RL9 SWIG is provided via 'CRB'
+      - name: Enable CRB (Rocky Linux >=9)
+        if: matrix.version >= 9
+        run: |
+          dnf install "dnf-command(config-manager)"
+          dnf config-manager --set-enabled crb
+
+      # we need to install a few build dependencies to support
+      # make-downloads, these are listed in the spec file
+      - name: Install build dependencies
+        run: yum-builddep -y htgettoken.spec
+
+      - name: Create distributions
+        run: make sources
+
+      - name: Create source package
+        run: |
+          rpmbuild \
+              --define "_sourcedir $(pwd)" \
+              --define "_srcrpmdir $(pwd)" \
+              -bs \
+              htgettoken.spec
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: srpm-${{ matrix.distro }}-${{ matrix.version }}
+          path: "*.src.rpm"
+          if-no-files-found: error
+
+  # Build the binary RPM(s)
+  rhel-rpm:
+    name: EL ${{ matrix.version }} (${{ matrix.distro }}) binary package(s)
+    needs:
+      - rhel-srpm
+    strategy:
+      fail-fast: false
+      matrix:
+        # Build for CentOS 7, and Rockylinux >=8
+        include:
+          - distro: centos
+            version: 7
+          - distro: rockylinux
+            version: 8
+          - distro: rockylinux
+            version: 9
+    runs-on: ubuntu-latest
+    container: ${{ matrix.distro }}:${{ matrix.version }}
+    steps:
+      - name: Download SRPM
+        uses: actions/download-artifact@v2
+        with:
+          name: srpm-${{ matrix.distro }}-${{ matrix.version }}
+
+      - name: Install build tools
+        run: |
+          yum -y -q install rpm-build yum-utils
+
+      # on RL9 SWIG is provided via 'CRB'
+      - name: Enable CRB (Rocky Linux >=9)
+        if: matrix.version >= 9
+        run: |
+          dnf install "dnf-command(config-manager)"
+          dnf config-manager --set-enabled crb
+
+      - name: Install build dependencies
+        run: yum-builddep -y htgettoken-*.src.rpm
+
+      - name: List installed packages
+        run: yum list installed
+
+      - name: Build binary packages
+        run: |
+          rpmbuild --rebuild --define "_rpmdir $(pwd)" htgettoken-*.src.rpm
+          rm -f *.src.rpm
+          mv */*.rpm .
+
+      - name: Print package info
+        run: |
+          # print contents of packages
+          for rpmf in *.rpm; do
+              echo "===== ${rpmf} ======="
+              rpm --query --package "${rpmf}" --info
+              echo "----- Files: --------"
+              rpm --query --package "${rpmf}" --list
+              echo "----- Provides: -----"
+              rpm --query --package "${rpmf}" --provides
+              echo "----- Requires: -----"
+              rpm --query --package "${rpmf}" --requires
+          done
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: rpm-${{ matrix.distro }}-${{ matrix.version }}
+          path: "*.rpm"
+          if-no-files-found: error
+
+  # Install the binary RPM(s) and sanity check
+  rhel-install:
+    name: EL ${{ matrix.version }} (${{ matrix.distro }}) install test
+    needs:
+      - rhel-rpm
+    strategy:
+      fail-fast: false
+      matrix:
+        # Build for CentOS 7, and Rockylinux >=8
+        include:
+          - distro: centos
+            version: 7
+          - distro: rockylinux
+            version: 8
+          - distro: rockylinux
+            version: 9
+    runs-on: ubuntu-latest
+    container: ${{ matrix.distro }}:${{ matrix.version }}
+    steps:
+      - name: Download RPMs
+        uses: actions/download-artifact@v2
+        with:
+          name: rpm-${{ matrix.distro }}-${{ matrix.version }}
+
+      - name: Configure EPEL (EL7)
+        if: matrix.version < 8
+        run: yum -y install epel-release
+
+      - name: Install RPMs
+        run: yum -y install *.rpm
+
+      - name: Test htgettoken
+        run: /usr/bin/htgettoken --help

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,80 @@
+name: Python tests
+
+on:
+  push:
+    branches:
+      - gha-test
+      - main
+      - master
+      - release/**
+  pull_request:
+    branches:
+      - gha-test
+      - main
+      - master
+      - release/**
+
+jobs:
+  python:
+    # -- Python tests --
+    #
+    # This job tests the basic functionality
+    # of htgettoken.
+    #
+    # We use conda/mamba to install the requirements
+    # to avoid having to compile M2Crypto and/or pyOpenSSL
+    # on-the-fly
+    #
+
+    name: Python ${{ matrix.python-version }} (${{ matrix.os }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macOS
+          - Ubuntu
+        python-version:
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+    runs-on: ${{ matrix.os }}-latest
+    defaults:
+      run:
+        # this is needed for conda environments to activate automatically
+        shell: bash -el {0}
+    steps:
+      - name: Get source code
+        uses: actions/checkout@v2
+
+      - name: Configure conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: test
+          miniforge-variant: Mambaforge
+          python-version: ${{ matrix.python-version }}
+          use-mamba: true
+
+      - name: Install requirements
+        run: |
+          mamba install --name test \
+              m2crypto \
+              paramiko \
+              pyopenssl \
+          ;
+
+      - name: Install pykerberos (Unix)
+        if: matrix.os != 'Windows'
+        run: mamba install --name test pykerberos
+
+      - name: Install winkerberos (Windows)
+        if: matrix.os == 'Windows'
+        run: mamba install --name test winkerberos
+
+      - name: List installed packages
+        run: mamba list --name test
+
+      - name: Test htgettoken
+        run: ./htgettoken --help

--- a/htgettoken.spec
+++ b/htgettoken.spec
@@ -17,6 +17,7 @@ BuildRequires: python3-pip
 BuildRequires: python3-devel
 # swig and openssl-devel are needed to prevent an M2Crypto problem with
 #   OpenSSL 1.1
+BuildRequires: gcc
 BuildRequires: swig
 BuildRequires: openssl-devel
 

--- a/htgettoken.spec
+++ b/htgettoken.spec
@@ -18,6 +18,7 @@ BuildRequires: python3-devel
 # swig and openssl-devel are needed to prevent an M2Crypto problem with
 #   OpenSSL 1.1
 BuildRequires: gcc
+BuildRequires: krb5-devel
 BuildRequires: swig
 BuildRequires: openssl-devel
 

--- a/make-downloads
+++ b/make-downloads
@@ -13,7 +13,7 @@ fi
 PATH=$PWD/$BASE/.local/bin:$PATH
 export PYTHONPATH=`echo $PWD/$BASE/.local/lib/*/site-packages`
 PIPOPTS="download --no-cache-dir -d $PWD/$BASE"
-pip3 $PIPOPTS pyinstaller
+pip3 $PIPOPTS "pyinstaller<5.0"
 pip3 $PIPOPTS m2crypto
 pip3 $PIPOPTS pyOpenSSL
 pip3 $PIPOPTS kerberos


### PR DESCRIPTION
This PR closes #53 by implementing a GitHub Actions-based CI pipeline. The two workflows are as follows:

- `build.yml` - build SRPMs then binary RPMs and install then, then run `htgettoken --help`, for a variety of RHEL versions
- `test.yml` - use conda to install the known requirements, then run `htgettoken --help`, for a variety of Python versions

Along the way I had to make minor modifications to the spec file and the `make-downloads` script:

- 2b48b5a: add 'missing' `BuildRequires: gcc`, needed to build m2crypto from the tarball
- f14cafe: add 'missing' `BuildRequires: krb5-devel', needed to build pykerberos from the tarball (this is brought in on RHEL < 9 by `openssl-devel`)
- 90d3d6a: pin `pyinstaller` to 4.x to avoid https://github.com/pyinstaller/pyinstaller/pull/6660