### PR TITLE
Migrate from python-kerberos to python-gssapi

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,15 +63,8 @@ jobs:
               m2crypto \
               paramiko \
               pyopenssl \
+              python-gssapi \
           ;
-
-      - name: Install pykerberos (Unix)
-        if: matrix.os != 'Windows'
-        run: mamba install --name test pykerberos
-
-      - name: Install winkerberos (Windows)
-        if: matrix.os == 'Windows'
-        run: mamba install --name test winkerberos
 
       - name: List installed packages
         run: mamba list --name test

--- a/htgettoken
+++ b/htgettoken
@@ -5,7 +5,7 @@
 # Nonstandard python libraries required:
 #  m2crypto
 #  pyOpenSSL
-#  kerberos
+#  gssapi
 #
 # This source file is Copyright (c) 2020, FERMI NATIONAL
 #   ACCELERATOR LABORATORY.  All rights reserved.
@@ -34,7 +34,7 @@ import subprocess
 import signal
 import time
 import secrets
-import kerberos
+import gssapi
 import paramiko
 from optparse import OptionParser
 
@@ -1001,14 +1001,13 @@ def main():
                 os.environ["KRB5_CONFIG"] = cfgfile.name + ':' + krb5_config
             if options.debug:
                 log("Setting KRB5_CONFIG=" + os.getenv("KRB5_CONFIG"))
-            kcontext = None
+            kname = gssapi.Name(base=service, name_type=gssapi.NameType.hostbased_service)
+            kcontext = gssapi.SecurityContext(usage="initiate", name=kname)
+            kresponse = None
             try:
-                __, kcontext = kerberos.authGSSClientInit(service=service,
-                                    mech_oid=kerberos.GSS_MECH_OID_SPNEGO,
-                                    principal=options.kerbprincipal)
-                kerberos.authGSSClientStep(kcontext, "")
+                kresponse = kcontext.step()
             except Exception as e:
-                kcontext = None
+                raise
                 if krb5_config is None and (len(e.args) != 2 or \
                         len(e.args[1]) != 2 or 'expired' not in e.args[1][0]):
                     # Try again with the default KRB5_CONFIG because 
@@ -1021,15 +1020,13 @@ def main():
                     os.environ["KRB5_CONFIG"] = cfgfile.name + ":/etc/krb5.conf"
                     if options.debug:
                         log("Setting KRB5_CONFIG=" + os.getenv("KRB5_CONFIG"))
+                    kcontext = gssapi.SecurityContext(usage="initiate", name=kname)
                     try:
-                        __, kcontext = kerberos.authGSSClientInit(service=service,
-                                            mech_oid=kerberos.GSS_MECH_OID_SPNEGO,
-                                            principal=options.kerbprincipal)
-                        kerberos.authGSSClientStep(kcontext, "")
+                        kresponse = kcontext.step()
                     except Exception as e2:
-                        kcontext = None
+                        kresponse = None
                         e = e2
-                if kcontext is None:
+                if kresponse is None:
                     if options.verbose:
                         elog("Kerberos init failed", e)
                     elif showprogress:
@@ -1037,8 +1034,8 @@ def main():
 
             cfgfile.close()
 
-            if kcontext != None:
-                kerberostoken = kerberos.authGSSClientResponse(kcontext)
+            if kresponse != None:
+                kerberostoken = base64.b64encode(kresponse).decode()
                 if options.debug:
                     log("Kerberos token:", kerberostoken)
 

--- a/htgettoken.spec
+++ b/htgettoken.spec
@@ -21,6 +21,10 @@ BuildRequires: gcc
 BuildRequires: krb5-devel
 BuildRequires: swig
 BuildRequires: openssl-devel
+# for python-gssapi >= 1.8.0 (Python >=3.7)
+%if 0%{?rhel} >= 9
+BuildRequires: python3-Cython
+%endif
 
 # Needed by httokendecode
 Requires: jq

--- a/make-downloads
+++ b/make-downloads
@@ -16,7 +16,7 @@ PIPOPTS="download --no-cache-dir -d $PWD/$BASE"
 pip3 $PIPOPTS "pyinstaller<5.0"
 pip3 $PIPOPTS m2crypto
 pip3 $PIPOPTS pyOpenSSL
-pip3 $PIPOPTS kerberos
+pip3 $PIPOPTS gssapi
 pip3 $PIPOPTS paramiko
 pip3 $PIPOPTS wheel
 tar czvf $BASE.tar.gz $BASE


### PR DESCRIPTION
This PR replaces usage of `python-kerberos` with `python-gssapi`, which I understand to be an effective replacement for the former that is better distributed (`python36-gssapi` exists in EPEL7).