### PR TITLE
Replace use of m2crypto & pyOpenSSL with urllib3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,9 +60,8 @@ jobs:
       - name: Install requirements
         run: |
           mamba install --name test \
-              m2crypto \
+              urllib3 \
               paramiko \
-              pyopenssl \
           ;
 
       - name: Install pykerberos (Unix)

--- a/htgettoken
+++ b/htgettoken
@@ -3,9 +3,9 @@
 # htgettoken gets OIDC bearer tokens by interacting with Hashicorp vault
 #
 # Nonstandard python libraries required:
-#  m2crypto
-#  pyOpenSSL
 #  kerberos
+#  paramiko
+#  urllib3
 #
 # This source file is Copyright (c) 2020, FERMI NATIONAL
 #   ACCELERATOR LABORATORY.  All rights reserved.
@@ -33,26 +33,13 @@ import tempfile
 import subprocess
 import signal
 import time
+import logging
 import secrets
 import kerberos
 import paramiko
 from optparse import OptionParser
-
-try:
-    from http import client as http_client
-    from urllib import request as urllib_request
-    from urllib import parse as urllib_parse
-    from urllib.error import HTTPError
-    # the following is just a hint for pyinstaller
-    from http import cookies as http_cookies
-except ImportError: # python < 3
-    import httplib as http_client
-    import urllib2 as urllib_request
-    from urllib2 import HTTPError
-    import urlparse as urllib_parse
-
-from M2Crypto import SSL, X509, EVP, RSA, ASN1, m2
-from OpenSSL import crypto
+import urllib3
+import http.client
 
 # get the default certificates paths for this platform
 _paths = ssl.get_default_verify_paths()
@@ -82,7 +69,9 @@ defaults = {
 options = None
 showprogress = False
 logfile = sys.stderr
+vaultserver = None
 vaulthostname = None
+vault = None # default instance of the vaulthost class
 
 # enable printing utf-8 without crashing
 sys.stdout = open(1, 'w', encoding='utf-8', closefd=False)
@@ -93,8 +82,17 @@ sys.stderr = open(2, 'w', encoding='utf-8', closefd=False)
 def log(*args, **kwargs):
     print(" ".join(map(str,args)), file=logfile, **kwargs)
 
-# send debug output from http_client to the log function
-http_client.print = log
+# define custom logger handler for urllib3 to send output to our log function
+class HtgettokenHandler(logging.StreamHandler):
+    def __init__(self):
+        logging.StreamHandler.__init__(self)
+    def emit(self, record):
+        log(self.format(record))
+root_logger = logging.getLogger()
+log_format = '%(name)s - %(levelname)s - %(message)s'
+log_handler = HtgettokenHandler()
+log_handler.setFormatter(logging.Formatter(log_format))
+root_logger.addHandler(log_handler)
 
 # always print to stderr
 def logerr(*args, **kwargs):
@@ -117,25 +115,7 @@ def fatal(msg, code=1):
 def expandexception(e):
     typ = type(e).__name__
     msg = typ + ': ' + str(e)
-    if typ == 'HTTPError':
-        errmsg = e.read().decode()
-        try:
-            decoded = json.loads(errmsg)
-            errmsg = ':'
-            if 'errors' in decoded:
-                for error in decoded['errors']:
-                    errmsg += ' ' + error
-            elif 'warnings' in decoded:
-                for warning in decoded['warnings']:
-                    errmsg += ' ' + warning
-            else:
-                errmsg = ''
-                for key in decoded.keys():
-                    errmsg += ', ' + key + ': ' + str(decoded[key])
-        except:
-            errmsg = ' ' + errmsg
-        msg += errmsg
-    elif typ == 'GSSError':
+    if typ == 'GSSError':
         msg = typ + ':'
         for arg in e.args:
             msg += ' ' + arg[0] + '.'
@@ -150,265 +130,92 @@ def elog(msg, e):
     log(msg + ': ' + expandexception(e))
 
 
-# Make a wrapper so a SSL Connection object can be opened as a file.
-# this is mostly from
-# http://git.ganeti.org/?p=ganeti.git;a=commitdiff;h=beba56ae8;hp=70c815118f7f8bf151044cb09868d1e3d7a63ac8
-class _SslSocketWrapper(object):
-    def __init__(self, conn):
-        self._conn = conn
+# This is very similar to corresponding code in the HTCondor VaultCredmon.
+# A host may be round-robin. This uses an HTTPSConnectionPool to continue
+# to use the same IP address for multiple connections.  If there is a
+# connection timeout the IP address that caused it is removed from
+# consideration.
+class vaulthost:
+    ips = []
+    pool = None
+    host = ""
+    port = 0
+    hostalias = None
 
-    def __getattr__(self, name):
-        # forward everything to underlying connection
-        return getattr(self._conn, name)
-
-    def makefile(self, mode, bufsize=0):
-        try:
-            return socket.SocketIO(self._conn, mode)
-        except AttributeError:  # python < 3
-            return socket._fileobject(self._conn, mode, bufsize)
+    def __init__(self, parsedurl):
+        self.host = parsedurl.host
+        self.port = parsedurl.port
+        if options.vaultcertname is None:
+            self.hostalias = self.host
+        else:
+            self.hostalias = options.vaultcertname
 
     def close(self):
-        # m2crypto always shuts down the SSL connection in the connection
-        #  close() function
-        ret = self._conn.close()
-        if (self._conn.get_shutdown() & 1) != 1:
-            logerr(prog + " program warning: close did not send shutdown")
-        return ret
+        if self.pool != None:
+            self.pool.close()
+            self.pool = None
 
-# Validate a certificate on an HTTPS connection with M2Crypto.
-# The primary reason for this is that by default the RHEL7 Python version
-#  2.7.5 does not verify host names on https connections.  According to
-#   https://access.redhat.com/articles/2039753
-# that could however be enabled more simply with
-#    ssl._https_verify_certificates()
-# although that is a RHEL7-specific feature and may not solve the problem
-# everywhere we want to use htgettoken.  Perhaps instead I should just
-# depend on always using python3.  If I do switch it to use the standard
-# HTTPSConnection class, remember to test what happens with timeouts and
-# find an alternative to the vaulthostname override from --vaultalias.
-# This also implements switching between multiple IP addresses in a 
-# round-robin after timeouts so that is something else that needs to be
-# preserved.
-# 
-class CertValidatingHTTPSConnection(http_client.HTTPConnection):
-    default_port = http_client.HTTPS_PORT
-    ssl_timeout = 15
-    hostcache = {}
+    def getips(self):
+        info = socket.getaddrinfo(self.host, 0, 0, socket.IPPROTO_TCP)
 
-    def __init__(self, host, port, key_file=None, cert_file=None,
-                 cert_chain_file=None, cafile=None, capath=None, **kwargs):
-        http_client.HTTPConnection.__init__(self, host, port, **kwargs)
-        self.host = host
-        if port is None:
-            self.port = self.default_port
-        else:
-            self.port = port
-        self.key_file = key_file
-        self.cert_file = cert_file
-        self.cert_chain_file = cert_chain_file
-        self.cafile = cafile
-        self.capath = capath
-
-    @classmethod
-    def set_timeout(cls, time):
-        oldtime = cls.ssl_timeout
-        cls.ssl_timeout = time
-        return oldtime
-
-    def setconntimeouts(self, sslconn, value):
-        if options.debug:
-            log("Setting timeout to %d" % value)
-        if "settimeout" in dir(SSL.Connection):
-            # this improves the error message when it is available
-            # from "Operation now in progress" to "timed out"
-            sslconn.settimeout(value)
-        timeout = SSL.timeout(value)
-        sslconn.set_socket_read_timeout(timeout)
-        sslconn.set_socket_write_timeout(timeout)
-
-    def connect(self):
-        # 'sslv23' actually means to accept all, then we turn off
-        #   insecure sslv2 & sslv3
-        context = SSL.Context('sslv23')
-        # many websites say to disable SSL compression for CRIME attack
-        #  but unfortunately m2crypto doesn't have a constant for it
-        SSL_OP_NO_COMPRESSION = 0x00020000
-        context.set_options(m2.SSL_OP_NO_SSLv2 |
-                            m2.SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION)
-        # the example used for M2Crypto connections was mostly
-        #   https://www.heikkitoivonen.net/blog/2008/10/14/ssl-in-python-26/
-        if (self.cert_file is not None) or (self.key_file is not None):
-            context.load_cert(self.cert_file, self.key_file)
-        if self.cert_chain_file is not None:
-            context.load_cert_chain(self.cert_chain_file)
-        # Note that m2crypto does not verify CRLs.  There is an
-        # extension package m2ext that does, but ignoring CRLs for the
-        # well-managed servers that htgettoken connects to is deemed to
-        # be an acceptable risk.
-        context.set_verify(
-            SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, depth=9)
-        if context.load_verify_locations(self.cafile, self.capath) != 1:
-            raise RuntimeError('Could not load verify locations ' +
-                               str(self.cafile) + ' ' + str(self.capath))
-        # The following cipher list is from "Disable weak ciphers" on
-        # https://www.owasp.org/index.php/Transport_Layer_Protection_Cheat_Sheet
-        # combined with the openssl man page at
-        # https://www.openssl.org/docs/manmaster/apps/ciphers.html
-        # You can see what remains by passing this list to
-        #   openssl ciphers -v.
-        if context.set_cipher_list('DEFAULT:!eNULL:!aNULL:!ADH:!EXP:!LOW:!MD5:!IDEA:!RC4:@STRENGTH') != 1:
-            fatal("No valid ciphers")
-
-        ips = []
-        firsttry = False
-        if self.host in self.hostcache:
-            ips = self.hostcache[self.host]
-        else:
-            firsttry = True
-            try:
-                info = socket.getaddrinfo(self.host, 0, 0, socket.IPPROTO_TCP)
-            except Exception as e:
-                efatal("getting address info for %s failed" % self.host, e)
-            
-            # prefer IPV4
-            for tuple in info:
-                if tuple[0] == socket.AF_INET:
-                    ips.append(tuple[4][0])
+        self.ips = []
+        # Use only IPv4 addresses if there are any
+        for tuple in info:
+            if tuple[0] == socket.AF_INET:
+                self.ips.append(tuple[4][0])
+        if len(self.ips) == 0:
+            # Otherwise use the IPv6 addresses
             for tuple in info:
                 if tuple[0] == socket.AF_INET6:
-                    ips.append(tuple[4][0])
+                    self.ips.append(tuple[4][0])
+        if len(self.ips) == 0:
+            raise RuntimeError('no ip address found for', self.host)
 
-            self.hostcache[self.host] = ips
+    def newpool(self):
+        if self.pool != None:
+            self.pool.close()
+        self.pool = urllib3.HTTPSConnectionPool(self.ips[0],
+                            timeout=urllib3.util.Timeout(connect=2, read=10),
+                            assert_hostname=self.hostalias, port=self.port,
+                            ca_cert_dir=options.capath, ca_certs=options.cafile)
 
-        if options.debug:
-            log("IP addresses for %s: %s" % (self.host, str(ips)))
-
-        sslconn = None
-        lastexcept = None
-        lastip = None
-
-        numips = len(ips)
-        for idx in range(numips):
-            ip = ips[idx]
-            sslconn = SSL.Connection(context)
-            # set connection timeouts to just 5 seconds
-            self.setconntimeouts(sslconn, 5)
+    def request(self, path, headers=None, params=None, data=None, ignore_400=False):
+        if len(self.ips) == 0:
+            self.getips()
+            self.newpool()
+        while len(self.ips) > 0:
             try:
-                if options.debug or (firsttry and options.verbose and idx == 0 and numips > 1):
-                    log("Connecting to %s" % ip)
-                # Insert the expected host name back into the host name check.
-                # This is better then checking the SANs after the fact because
-                #  m2crypto also correctly matches wildcard certs.
-                checkfunc = sslconn.clientPostConnectionCheck
-                def overridecheck(cert, ip):
+                method = 'GET'
+                if data != None:
+                    method = 'POST'
+                resp = self.pool.request(method, path, headers=headers, fields=params, body=data, retries=0)
+            except urllib3.exceptions.MaxRetryError as e:
+                if type(e.reason) != urllib3.exceptions.ConnectTimeoutError:
+                    raise e
+                if len(self.ips) == 1:
+                    raise e
+                if options.verbose:
+                    log('Connection timeout on %s ip %s, trying %s' % (self.host, self.ips[0], self.ips[1]))
+                del self.ips[0]
+                self.newpool()
+            else:
+                if resp.status == 400 and ignore_400:
                     if options.debug:
-                        log("Verifying host cert for %s against host name %s" % (ip, self.host))
-                    return checkfunc(cert, self.host)
-                sslconn.clientPostConnectionCheck = overridecheck
-                sslconn.connect((ip, self.port))
-            except SSL.Checker.WrongHost as e:
-                # Also allow the vaultalias (via the derived vaulthostname),
-                #  although this doesn't work with wildcard host certs.
-                # The vaultalias is also used for the kerberos cluster
-                #  name, so checking it after an exception like this
-                #  avoids having to have separate options for kerberos
-                #  and https aliases.
-                if vaulthostname is None:
-                    raise e
-                elif 'DNS:'+vaulthostname+',' not in e.actualHost+',':
-                    e.expectedHost = e.expectedHost + ' or ' + vaulthostname
-                    raise e
-                if options.debug:
-                    log("Host cert didn't allow %s but matched %s" % (e.expectedHost, vaulthostname))
-            except Exception as e:
-                if options.debug:
-                    elog("Connect attempt to %s port %d failed" % (ip, self.port), e)
-                valid_family = False
-                if type(e) != socket.gaierror or e.args[0] != socket.EAI_ADDRFAMILY:
-                    # Don't show "Address family for host name not supported"
-                    #  when not in debug; it probably means means IPv6 (or
-                    #  IPv4) is not available on the client
-                    valid_family = True
-                    lastexcept = e
-                    lastip = ip
-                if idx < numips - 1:
-                    if options.verbose and valid_family:
-                        msg = str(e)
-                        if len(e.args) > 1:
-                            msg = e.args[1]
-                        log("Connect to %s failed (%s), trying %s" % (ip, msg, ips[idx+1]))
-                else:
-                    if lastexcept != None:
-                        e = lastexcept
-                        ip = lastip
-                    efatal("Connect to %s (%s) failed" % (self.host, ip), e)
-                sslconn.close()
-                continue
+                        log("ignoring 400 status")
+                    return resp
+                if resp.status != 200 and resp.status != 204:
+                    errormsg = http.client.responses[resp.status] + ":"
+                    try:
+                        jsondata = json.loads(resp.data.decode())
+                    except:
+                        errormsg += ' ' + resp.data.decode()
+                    else:
+                        if 'errors' in jsondata:
+                            for error in jsondata['errors']:
+                                errormsg += ' ' + error.encode('ascii','ignore').decode('ascii')
+                    raise urllib3.exceptions.HTTPError(errormsg)
 
-            if options.debug:
-                log("Connect to %s succeeded" % self.host)
-            # connect succeeded
-            if idx > 0:
-                # delete failed ip addresses from the host cache
-                self.hostcache[self.host] = ips[idx:]
-            break
-
-        # set post-connection timeouts
-        self.setconntimeouts(sslconn, self.ssl_timeout)
-
-        self.sock = _SslSocketWrapper(sslconn)
-
-# One API call requires reading the body of a 400 error, so to enable
-#  that call VerifiedHTTPSHandler.set_ignore_400() and to disable it
-#  call VerifiedHTTPSHandler.clear_ignore_400()
-class VerifiedHTTPSHandler(urllib_request.HTTPSHandler):
-    ignore_400 = False
-
-    @classmethod
-    def set_ignore_400(cls):
-        cls.ignore_400 = True
-
-    @classmethod
-    def clear_ignore_400(cls):
-        cls.ignore_400 = False
-
-    @classmethod
-    def is_400_ignored(cls):
-        return cls.ignore_400
-
-    def __init__(self, **kwargs):
-        urllib_request.HTTPSHandler.__init__(self)
-        self._connection_args = kwargs
-
-    def https_open(self, req):
-        def http_class_wrapper(netloc, **kwargs):
-            full_kwargs = dict(self._connection_args)
-            full_kwargs.update(kwargs)
-            p = urllib_parse.urlsplit('https://'+netloc)
-            return CertValidatingHTTPSConnection(p.hostname, p.port, **full_kwargs)
-
-        return self.do_open(http_class_wrapper, req)
-
-    def http_error_400(self, request, fp, code, msg, hdrs):
-        if self.is_400_ignored():
-            if options.debug:
-                log("ignoring 400 " + msg)
-            return fp
-        raise HTTPError(request.get_full_url(), code, msg, hdrs, fp)
-
-class CompletingHTTPResponse(http_client.HTTPResponse):
-
-    # Override the _safe_read function when requesting a specific number
-    #  of bytes, to avoid IncompleteRead exception seen with python3.8,
-    #  apparently related somehow to M2Crypto
-    def _safe_read(self, amt):
-        data = bytearray()
-        while len(data) < amt:
-            ret = self.fp.read(amt-len(data))
-            if len(ret) == 0:
-                raise http_client.IncompleteRead(amt, amt-len(data))
-            data.extend(ret)
-        return data
+                return resp
 
 
 # function from http://stackoverflow.com/questions/4407539/python-how-to-make-an-option-to-be-required-in-optparse
@@ -439,7 +246,7 @@ def parseargs(parser, argv):
 # Either extract the vault token from an auth response or exchange
 #  it for another one if either the lease_duration is too long or it
 #  includes an sshregister policy.
-def getVaultToken(opener, vaultserver, vaulttokensecs, response):
+def getVaultToken(vaulttokensecs, response):
     if 'auth' not in response:
         fatal("no 'auth' in response from %s" % vaultserver)
     auth = response['auth']
@@ -462,7 +269,8 @@ def getVaultToken(opener, vaultserver, vaulttokensecs, response):
         return vaulttoken
 
     # do a vault token exchange
-    url = vaultserver + '/v1/' + 'auth/token/create'
+    path = '/v1/' + 'auth/token/create'
+    url = vaultserver + path
     if options.debug:
         # normally do this quietly; don't want to advertise the exchange
         log("Reading from", url)
@@ -474,13 +282,11 @@ def getVaultToken(opener, vaultserver, vaulttokensecs, response):
     if policies is not None:
         data['policies'] = policies
 
-    request = urllib_request.Request(url=url, headers=headers, data=json.dumps(data).encode())
-    handle = None
     try:
-        handle = opener.open(request)
+        resp = vault.request(path, headers=headers, data=json.dumps(data).encode())
     except Exception as e:
         efatal("getting vault token from %s failed" % url, e)
-    body = handle.read()
+    body = resp.data.decode()
     if options.debug:
         log("##### Begin vault token response")
         log(body)
@@ -495,20 +301,19 @@ def getVaultToken(opener, vaultserver, vaulttokensecs, response):
 
 # Check for a minimum number of seconds remaining in vault token
 # Return True if there's enough time remaining, else False
-def checkVaultMinsecs(opener, vaultserver, vaulttoken, vaulttokenminsecs):
+def checkVaultMinsecs(vaulttoken, vaulttokenminsecs):
     # Look up info about the vault token
-    url = vaultserver + '/v1/' + 'auth/token/lookup-self'
+    path = '/v1/' + 'auth/token/lookup-self'
+    url = vaultserver + path
     if options.debug:
         log("Reading from", url)
     headers = {'X-Vault-Token': vaulttoken}
-    request = urllib_request.Request(url=url, headers=headers)
-    handle = None
     try:
-        handle = opener.open(request)
+        resp = vault.request(path, headers=headers)
     except Exception as e:
         elog("Looking up vault token at %s failed" % url, e)
         return False
-    body = handle.read()
+    body = resp.data.decode()
     if options.debug:
         log("##### Begin vault lookup-self response")
         log(body)
@@ -528,7 +333,7 @@ def checkVaultMinsecs(opener, vaultserver, vaulttoken, vaulttokenminsecs):
     return False
 
 # Read a bearer token from vault
-def getBearerToken(opener, vaultserver, vaulttoken, vaultpath):
+def getBearerToken(vaulttoken, vaultpath):
     if options.showbearerurl:
         print(vaultserver + '/v1/' + vaultpath)
         options.showbearerurl = False
@@ -539,28 +344,25 @@ def getBearerToken(opener, vaultserver, vaulttoken, vaultpath):
         log("  at path " + vaultpath)
     elif showprogress:
         log("Attempting to get token from " + vaultserver + " ...", end='', flush=True)
-    url = vaultserver + '/v1/' + vaultpath
+    path = '/v1/' + vaultpath
+    url = vaultserver + path
     params = {'minimum_seconds': options.minsecs}
     if options.scopes is not None:
         params['scopes'] = options.scopes
     if options.audience is not None:
         params['audience'] = options.audience
-    url = url + '?' + urllib_parse.urlencode(params)
     if options.debug:
         log("Reading from", url)
     headers = {'X-Vault-Token': vaulttoken}
-    request = urllib_request.Request(url=url, headers=headers)
-    handle = None
     try:
-        handle = opener.open(request)
+        resp = vault.request(path, headers=headers, params=params)
     except Exception as e:
         if options.verbose:
             elog("Read token from %s failed" % url, e)
         elif showprogress:
             log(" failed")
         return None
-    handle.__class__ = CompletingHTTPResponse
-    body = handle.read()
+    body = resp.data.decode()
     if options.debug:
         log("##### Begin vault get bearer token response")
         log(body)
@@ -669,6 +471,9 @@ def main():
     parser.add_option("--vaultalias",
                       metavar="HostOrURL",
                       help="vault alias service name or URL [default same as vaultserver]")
+    parser.add_option("--vaultcertname",
+                      metavar="Host",
+                      help="host certificate name to expect for vault server [default host name part of vaultserver]")
     parser.add_option("-i", "--issuer",
                       metavar="issuername",
                       default="default",
@@ -776,11 +581,8 @@ def main():
 
     parseargs(parser, envargs + sys.argv[1:])
 
-    httpshandler = VerifiedHTTPSHandler(
-        cafile=options.cafile, capath=options.capath)
     if options.debug:
-        httpshandler.set_http_debuglevel(1)
-    opener = urllib_request.build_opener(httpshandler)
+        http.client.HTTPConnection.debuglevel = 5
 
     if options.optserver is not None:
         # read additional options from optserver
@@ -792,15 +594,14 @@ def main():
             #  because it is too early to easily know if the options
             #  using stdout have been set
             log("Fetching options from " + optserver)
-        optrequest = urllib_request.Request(url=optserver)
+        optparsed = urllib3.util.parse_url(optserver)
+        opthost = vaulthost(optparsed)
         try:
-            opthandle = opener.open(optrequest)
+            resp = opthost.request(optparsed.path)
         except Exception as e:
             efatal("fetch of options from %s failed" % optserver, e)
-        opts = opthandle.read()
-        if isinstance(opts, bytes):
-            opts = str(opts.decode('utf-8'))
-        opthandle.close()
+        opts = resp.data.decode()
+        opthost.close()
         if options.debug:
             log("##### Begin additional options")
             log(opts)
@@ -875,15 +676,17 @@ def main():
             options.web_open_command = ""
 
     # Get and parse the vaultserver URL
+    global vaultserver
     vaultserver = options.vaultserver
     if '://' not in vaultserver:
         vaultserver = 'https://' + vaultserver
     vaultserverparts = vaultserver.split('/')
     if ':' not in vaultserverparts[2]:
         vaultserver = vaultserver + ':8200'
+    vaultserverparsed = urllib3.util.parse_url(vaultserver)
 
     vaultalias = vaultserver
-    vaultaliasparts = vaultserverparts
+    vaultaliasparsed = vaultserverparsed
     if options.vaultalias is not None:
         # Similarly parse the vaultalias option
         # This is used when there are multiple servers implementing the
@@ -895,9 +698,13 @@ def main():
         vaultaliasparts = vaultalias.split('/')
         if ':' not in vaultaliasparts[2]:
             vaultalias = vaultalias + ':8200'
+        vaultaliasparsed = urllib3.util.parse_url(vaultalias)
 
     global vaulthostname
-    vaulthostname = vaultaliasparts[2].split(':')[0]
+    vaulthostname = vaultaliasparsed.host
+
+    global vault
+    vault = vaulthost(vaultserverparsed)
 
     secretpath = options.secretpath.replace("%issuer", options.issuer)
     secretpath = secretpath.replace("%role", options.role)
@@ -962,23 +769,21 @@ def main():
 
                     # construct fake "response" for getVaultToken
                     response = {'auth' : {'client_token': vaulttoken}}
-                    vaulttoken = getVaultToken(opener, vaultserver, 
-                                                vaulttokensecs, response)
+                    vaulttoken = getVaultToken(vaulttokensecs, response)
                     writeTokenSafely("vault", vaulttoken, vaulttokenfile)
                 elif vaulttokenminsecs > 0:
                     if options.verbose:
                         log("Making sure there is at least " + str(vaulttokenminsecs) + " seconds remaining")
                         log("  in vault token from", vaulttokeninfile)
 
-                    tryget = checkVaultMinsecs(opener, vaultserver, vaulttoken, vaulttokenminsecs)
+                    tryget = checkVaultMinsecs(vaulttoken, vaulttokenminsecs)
             
                 if tryget:
                     if options.verbose and not options.nobearertoken:
                         log("Attempting to get bearer token from", vaultserver)
                         log("  using vault token from", vaulttokeninfile)
 
-                    bearertoken = getBearerToken(opener, vaultserver,
-                                                vaulttoken, fullsecretpath)
+                    bearertoken = getBearerToken(vaulttoken, fullsecretpath)
             
         if bearertoken is None and not options.nokerberos:
             # Try kerberos authentication with vault
@@ -1048,7 +853,8 @@ def main():
 
                 kerbpath = options.kerbpath.replace("%issuer", options.issuer)
                 kerbpath = kerbpath.replace("%role", options.role)
-                url = str(vaultserver) + "/v1/" + kerbpath + '/login'
+                path = "/v1/" + kerbpath + '/login'
+                url = vaultserver + path
                 if options.verbose:
                     log("Negotiating kerberos with", vaultserver)
                     log("  at path " + kerbpath)
@@ -1057,15 +863,14 @@ def main():
                     'Authorization': 'Negotiate ' + kerberostoken
                 }
                 data = ''.encode('ascii')  # empty data is to force a POST
-                request = urllib_request.Request(url=url, headers=headers, data=data)
                 try:
-                    handle = opener.open(request)
+                    resp = vault.request(path, headers=headers, data=data)
                 except Exception as e:
                     if showprogress:
                         log(" failed")
                     efatal("Kerberos negotiate with %s failed" % url, e)
 
-                body = handle.read()
+                body = resp.data.decode()
                 if options.debug:
                     log("##### Begin vault kerberos response")
                     log(body)
@@ -1074,12 +879,11 @@ def main():
                 if 'auth' in response and response['auth'] is not None:
                     if showprogress:
                         log(" succeeded")
-                    vaulttoken = getVaultToken(opener, vaultserver, vaulttokensecs, response)
+                    vaulttoken = getVaultToken(vaulttokensecs, response)
                     if options.verbose:
                         log("Attempting to get bearer token from " + vaultserver)
 
-                    bearertoken = getBearerToken(opener, vaultserver,
-                                                vaulttoken, fullsecretpath)
+                    bearertoken = getBearerToken(vaulttoken, fullsecretpath)
 
                     if bearertoken is not None:
                         # getting bearer token worked, write out vault token
@@ -1122,18 +926,17 @@ def main():
                     keynum += 1
                     keyname = 'key' + str(keynum)
 
-                    url = vaultserver + '/v1/' + options.sshpath + '/nonce'
+                    path = '/v1/' + options.sshpath + '/nonce'
+                    url = vaultserver + path
                     if options.verbose:
                         log("Getting ssh nonce from " + url)
-                    request = urllib_request.Request(url=url)
-                    handle = None
                     try:
-                        handle = opener.open(request)
+                        resp = vault.request(path)
                     except Exception as e:
                         if options.verbose:
                             elog("Getting ssh nonce failed", e)
                         break
-                    body = handle.read()
+                    body = resp.data.decode()
                     if options.debug:
                         log("##### Begin ssh-agent nonce response")
                         log(body)
@@ -1164,19 +967,18 @@ def main():
                         data['metadata'] = metadata
                     datastr = json.dumps(data)
 
-                    url = vaultserver + '/v1/' + options.sshpath + '/login'
+                    path = '/v1/' + options.sshpath + '/login'
+                    url = vaultserver + path
                     if options.verbose:
                         log("Attempting to login with ssh " + keyname + " at " + url)
-                    request = urllib_request.Request(url=url, data=datastr.encode())
-                    handle = None
                     try:
-                        handle = opener.open(request)
+                        resp = vault.request(path, data=datastr.encode())
                     except Exception as e:
                         if options.verbose:
                             elog("Logging in with ssh " + keyname + " failed", e)
                         continue
 
-                    body = handle.read()
+                    body = resp.data.decode()
                     if options.debug:
                         log("##### Begin ssh-agent login response")
                         log(body)
@@ -1190,12 +992,11 @@ def main():
                     if 'auth' in response and response['auth'] is not None:
                         if showprogress:
                             log(" succeeded")
-                        vaulttoken = getVaultToken(opener, vaultserver, vaulttokensecs, response)
+                        vaulttoken = getVaultToken(vaulttokensecs, response)
                         if options.verbose:
                             log("Attempting to get bearer token from " + vaultserver)
 
-                        bearertoken = getBearerToken(opener, vaultserver,
-                                                    vaulttoken, fullsecretpath)
+                        bearertoken = getBearerToken(vaulttoken, fullsecretpath)
 
                         if bearertoken is not None:
                             # getting bearer token worked, write out vault token
@@ -1220,7 +1021,8 @@ def main():
         if options.verbose or showprogress:
             log("Attempting OIDC authentication with", vaultserver)
         oidcpath = options.oidcpath.replace("%issuer", options.issuer)
-        url = vaultserver + '/v1/' + oidcpath + '/auth_url'
+        path = '/v1/' + oidcpath + '/auth_url'
+        url = vaultserver + path
         nonce = secrets.token_urlsafe()
         authdata = {
             'role': options.role,
@@ -1233,13 +1035,11 @@ def main():
             log("##### Begin authentication data")
             log(data)
             log("##### End authentication data")
-        request = urllib_request.Request(url=url, data=data.encode())
-        handle = None
         try:
-            handle = opener.open(request)
+            resp = vault.request(path, data=data.encode())
         except Exception as e:
             efatal("Initiating authentication to %s failed" % vaultserver, e)
-        body = handle.read()
+        body = resp.data.decode()
         if options.debug:
             log("##### Begin vault initiate auth response")
             log(body)
@@ -1299,14 +1099,15 @@ def main():
         data['client_nonce'] = nonce
         datastr = ''
         if 'state' in data:
-            url = vaultserver + '/v1/' + oidcpath + '/poll'
+            path = '/v1/' + oidcpath + '/poll'
             if 'poll_interval' in data:
                 pollinterval = int(data['poll_interval'])
                 del data['poll_interval']
         else:
             # backward compatibility for old device flow implementation
-            url = vaultserver + '/v1/' + oidcpath + '/device_wait'
+            path = '/v1/' + oidcpath + '/device_wait'
             data['role'] = options.role
+        url = vaultserver + path
         datastr = json.dumps(data)
         if options.debug:
             log("Continuing authentication at", url)
@@ -1318,35 +1119,24 @@ def main():
         response = None
         secswaited = 0
         while True:
-            request = urllib_request.Request(url=url, data=datastr.encode())
-            handle = None
             try:
-                if pollinterval == 0:
-                    # backward compatibility for old device flow implementation
-                    # increase the timeout for this potentially long response
-                    savetimeout = CertValidatingHTTPSConnection.set_timeout(300)
-                    handle = opener.open(request)
-                    CertValidatingHTTPSConnection.set_timeout(savetimeout)
-                else:
-                    if secswaited > 120:
-                        fatal("Polling for response took longer than 2 minutes")
-                    if options.debug:
-                        log("waiting for " + str(pollinterval) + " seconds")
-                    time.sleep(pollinterval)
-                    secswaited += pollinterval
-                    if options.debug:
-                        log("polling")
-                    # The normal "authorized_pending" response comes in
-                    #  the body of a 400 Bad Request.  If we let the
-                    #  exception go as normal, the handle gets closed and
-                    #  we can't read the body, so temporarily block 400 from
-                    #  throwing an exception.
-                    VerifiedHTTPSHandler.set_ignore_400()
-                    handle = opener.open(request)
-                    VerifiedHTTPSHandler.clear_ignore_400()
+                if secswaited > 120:
+                    fatal("Polling for response took longer than 2 minutes")
+                if options.debug:
+                    log("waiting for " + str(pollinterval) + " seconds")
+                time.sleep(pollinterval)
+                secswaited += pollinterval
+                if options.debug:
+                    log("polling")
+                # The normal "authorized_pending" response comes in
+                #  the body of a 400 Bad Request.  If we let the
+                #  exception go as normal, the resp is not set and we
+                #  can't read the body, so temporarily block 400 from
+                #  throwing an exception.
+                resp = vault.request(path, data=datastr.encode(), ignore_400=True)
             except Exception as e:
                 efatal("Authentication to %s failed" % vaultserver, e)
-            body = handle.read()
+            body = resp.data.decode()
             if options.debug:
                 log("##### Begin vault auth response")
                 log(body)
@@ -1397,14 +1187,13 @@ def main():
                 for pubkey in pubkeys:
                     log("  " + pubkey)
 
-            url = vaultserver + '/v1/' + options.sshpath + '/role/' + credkey
+            path = '/v1/' + options.sshpath + '/role/' + credkey
+            url = vaultserver + path
             data = {
                 'public_keys': pubkeys
             }
-            request = urllib_request.Request(url=url, headers=headers, data=json.dumps(data).encode())
-            handle = None
             try:
-                handle = opener.open(request)
+                resp = vault.request(path, headers=headers, data=json.dumps(data).encode())
             except Exception as e:
                 if showprogress:
                     log(" failed")
@@ -1413,7 +1202,7 @@ def main():
                 log(" done")
 
 
-        vaulttoken = getVaultToken(opener, vaultserver, vaulttokensecs, response)
+        vaulttoken = getVaultToken(vaulttokensecs, response)
         writeTokenSafely("vault", vaulttoken, vaulttokenfile)
 
         auth = response['auth']
@@ -1449,7 +1238,8 @@ def main():
             log("  at path " + fullsecretpath)
         elif showprogress:
             log("Saving refresh token ...", end='', flush=True)
-        url = vaultserver + '/v1/' + fullsecretpath
+        path = '/v1/' + fullsecretpath
+        url = vaultserver + path
         headers = {'X-Vault-Token': vaulttoken}
         storedata = {
             'server': options.issuer,
@@ -1461,10 +1251,8 @@ def main():
             log("##### Begin refresh token storage data")
             log(data)
             log("##### End refresh token storage data")
-        request = urllib_request.Request(url=url, headers=headers, data=data.encode())
-        handle = None
         try:
-            handle = opener.open(request)
+            resp = vault.request(path, headers=headers, data=data.encode())
         except Exception as e:
             if showprogress:
                 log(" failed")
@@ -1475,8 +1263,7 @@ def main():
         if options.verbose:
             log("Getting bearer token from " + vaultserver)
 
-        bearertoken = getBearerToken(opener, vaultserver,
-                                    vaulttoken, fullsecretpath)
+        bearertoken = getBearerToken(vaulttoken, fullsecretpath)
 
     if bearertoken is None:
         fatal("Failure getting token from " + vaultserver)

--- a/htgettoken
+++ b/htgettoken
@@ -186,6 +186,9 @@ class _SslSocketWrapper(object):
 # depend on always using python3.  If I do switch it to use the standard
 # HTTPSConnection class, remember to test what happens with timeouts and
 # find an alternative to the vaulthostname override from --vaultalias.
+# This also implements switching between multiple IP addresses in a 
+# round-robin after timeouts so that is something else that needs to be
+# preserved.
 # 
 class CertValidatingHTTPSConnection(http_client.HTTPConnection):
     default_port = http_client.HTTPS_PORT
@@ -197,7 +200,7 @@ class CertValidatingHTTPSConnection(http_client.HTTPConnection):
         http_client.HTTPConnection.__init__(self, host, port, **kwargs)
         self.host = host
         if port is None:
-            self.port = http_client.HTTPS_PORT
+            self.port = self.default_port
         else:
             self.port = port
         self.key_file = key_file
@@ -240,7 +243,7 @@ class CertValidatingHTTPSConnection(http_client.HTTPConnection):
             context.load_cert_chain(self.cert_chain_file)
         # Note that m2crypto does not verify CRLs.  There is an
         # extension package m2ext that does, but ignoring CRLs for the
-        # well-managed servers that cigetcert connects to is deemed to
+        # well-managed servers that htgettoken connects to is deemed to
         # be an acceptable risk.
         context.set_verify(
             SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, depth=9)
@@ -304,11 +307,12 @@ class CertValidatingHTTPSConnection(http_client.HTTPConnection):
                 sslconn.clientPostConnectionCheck = overridecheck
                 sslconn.connect((ip, self.port))
             except SSL.Checker.WrongHost as e:
-                # Also allow the vaultalias, although this doesn't work
-                #  with wildcard host certs.  The vaultalias is also used
-                #  for the kerberos cluster name, so checking it after an
-                #  exception like this avoids having to have separate
-                #  options for kerberos and https aliases.
+                # Also allow the vaultalias (via the derived vaulthostname),
+                #  although this doesn't work with wildcard host certs.
+                # The vaultalias is also used for the kerberos cluster
+                #  name, so checking it after an exception like this
+                #  avoids having to have separate options for kerberos
+                #  and https aliases.
                 if vaulthostname is None:
                     raise e
                 elif 'DNS:'+vaulthostname+',' not in e.actualHost+',':

--- a/htgettoken.1
+++ b/htgettoken.1
@@ -69,16 +69,21 @@ otherwise the whole URL is used.  This is the only required option.
 .RE
 .TP
 .BR \-\-vaultalias=HostOrURL
-The vault server DNS alias name.  This is mainly useful for debugging,
+The vault cluster name.  This is mainly useful for debugging,
 for example when multiple vault servers in a cluster are serving the
-same alias name and the address of a single server is supplied with
+same name and the address of a single server is supplied with
 .IR \-\-vaultserver .
 The
 .I \-\-vaultalias
-is then used to verify that the service name of the vault server 
-matches this expected name.  Default is the same as
-.IR \-\-vaultserver ,
-and the same URL protocol and port are added if they are not supplied.
+is then used when communicating with the name defined in the cluster,
+for example for kerberos.  Default is the same as
+.IR \-\-vaultserver .
+.TP
+.BR \-\-vaultcertname=Host
+The vault https certficate name.  This is mainly useful when testing
+and the name in the host certificate does not match the name used to
+access the server.  Default is the same as the host name part of
+.IR \-\-vaultserver .
 .TP
 .BR \-i\ issuername , \ \-\-issuer=issuername
 The name of the OIDC token issuer, as configured in the vault server. 

--- a/htgettoken.1
+++ b/htgettoken.1
@@ -361,7 +361,7 @@ server while showing all intermediate steps:
 .PP
 .RS
 .nf
-htgettoken -v -a htvault.fnal.gov -i dune
+htgettoken -v -a htvault.example.com -i dune
 .fi
 .RE
 .PP
@@ -379,7 +379,7 @@ To always have a default vault address:
 .PP
 .RS
 .nf
-export HTGETTOKENOPTS="-a htvault.fnal.gov"
+export HTGETTOKENOPTS="-a htvault.example.com"
 .fi
 .RE
 

--- a/htgettoken.spec
+++ b/htgettoken.spec
@@ -1,4 +1,4 @@
-%define downloads_version 1.7
+%define downloads_version 1.8
 
 Summary: Get OIDC bearer tokens by interacting with Hashicorp vault
 Name: htgettoken
@@ -126,6 +126,11 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+# - Replace use of m2crypto and pyOpenSSL with urllib3
+# - Add --vaultcertname option to specify an alternative certificate name.
+#   That used to be an additional optional meaning of the --vaultalias option,
+#   but urllib3 requires only one name to match.
+
 * Wed Oct 12 2022 Dave Dykstra <dwd@fnal.gov> 1.16-1
 - Fix httokendecode -H functionality to only attempt to convert a parsed word
   if it is entirely numeric, not if it just contains one digit.  At the same

--- a/make-downloads
+++ b/make-downloads
@@ -14,8 +14,7 @@ PATH=$PWD/$BASE/.local/bin:$PATH
 export PYTHONPATH=`echo $PWD/$BASE/.local/lib/*/site-packages`
 PIPOPTS="download --no-cache-dir -d $PWD/$BASE"
 pip3 $PIPOPTS "pyinstaller<5.0"
-pip3 $PIPOPTS m2crypto
-pip3 $PIPOPTS pyOpenSSL
+pip3 $PIPOPTS urllib3
 pip3 $PIPOPTS kerberos
 pip3 $PIPOPTS paramiko
 pip3 $PIPOPTS wheel


### PR DESCRIPTION
This borrows code from htcondor/htcondor#953 to simplify https handling and also use a better-supported python library.  Makes porting to el9 easier, at least without pyinstaller as is being attempted in #56.

- Also fixes #55