### PR TITLE
Refactor htgettoken script into a Python module with an entry point

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,13 @@ jobs:
         with:
           name: srpm-${{ matrix.distro }}-${{ matrix.version }}
 
+      # on RL9 python3-wheel is provided via 'CRB'
+      - name: Enable CRB (Rocky Linux >=9)
+        if: matrix.version >= 9
+        run: |
+          dnf -y -q install "dnf-command(config-manager)"
+          dnf config-manager --set-enabled crb
+
       - name: Configure EPEL
         run: yum -y install epel-release
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,21 +37,26 @@ jobs:
           - "3.10"
           - "3.11"
     runs-on: ${{ matrix.os }}-latest
+    defaults:
+      run:
+        # this is needed for conda environments to activate automatically
+        shell: bash -el {0}
+
     steps:
       - name: Get source code
         uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - name: Configure conda
+        uses: conda-incubator/setup-miniconda@v2
         with:
+          activate-environment: test
+          miniforge-variant: Mambaforge
           python-version: ${{ matrix.python-version }}
+          use-mamba: true
 
-      # install krb5-config for gssapi
-      # (this is needed because gssapi isn't installed from a wheel,
-      #  but from the tarball, boo)
-      - name: Install krb5-config for Linux
-        if: matrix.os == 'Ubuntu'
-        run: sudo apt-get -yqq update && sudo apt-get install -yqq libkrb5-dev
+      # install krb5 for gssapi
+      - name: Install krb5
+        run: mamba install krb5
 
       - name: Install htgettoken
         run: python -m pip install .

--- a/htgettoken.py
+++ b/htgettoken.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # htgettoken gets OIDC bearer tokens by interacting with Hashicorp vault
 #
 # Nonstandard python libraries required:

--- a/htgettoken.spec
+++ b/htgettoken.spec
@@ -76,6 +76,8 @@ rm -rf $RPM_BUILD_ROOT
 #   That used to be an additional optional meaning of the --vaultalias option,
 #   but urllib3 requires only one name to match.
 # - Add setuptools build infrastructure
+# - Refactor htgettoken script into module with entry point.
+#   This enables invoking htgettoken as `htgettoken.main()` from Python.
 
 * Wed Oct 12 2022 Dave Dykstra <dwd@fnal.gov> 1.16-1
 - Fix httokendecode -H functionality to only attempt to convert a parsed word

--- a/htgettoken.spec
+++ b/htgettoken.spec
@@ -22,7 +22,9 @@ BuildRequires: python3-rpm-macros
 
 # build dependencies
 BuildRequires: python3
+BuildRequires: python%{python3_pkgversion}-pip
 BuildRequires: python%{python3_pkgversion}-setuptools
+BuildRequires: python%{python3_pkgversion}-wheel
 
 # -- Package: htgettoken
 
@@ -52,11 +54,11 @@ htgettoken gets OIDC bearer tokens by interacting with Hashicorp vault
 %autosetup -n %{name}-%{version}
 
 %build
-%py3_build
+%py3_build_wheel
 
 %install
 # install the Python project
-%py3_install
+%py3_install_wheel %{name}-%{version}-*.whl
 # link htdecodetoken to httokendecode
 (cd %{buildroot}%{_bindir}/; ln -s httokendecode htdecodetoken)
 # install man page(s)
@@ -78,6 +80,8 @@ rm -rf $RPM_BUILD_ROOT
 # - Add setuptools build infrastructure
 # - Refactor htgettoken script into module with entry point.
 #   This enables invoking htgettoken as `htgettoken.main()` from Python.
+# - Use wheels to build/install Python package, which simplified the entry points
+#   and improves (slightly) the metadata
 
 * Wed Oct 12 2022 Dave Dykstra <dwd@fnal.gov> 1.16-1
 - Fix httokendecode -H functionality to only attempt to convert a parsed word

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,13 +28,19 @@ classifiers =
 	Programming Language :: Python :: 3.11
 
 [options]
+# contents
+py_modules =
+	htgettoken
 scripts =
 	htdestroytoken
-	htgettoken
 	httokendecode
-packages =
+# requirements
 python_requires = >=3.5
 install_requires =
 	gssapi
 	paramiko
 	urllib3
+
+[options.entry_points]
+console_scripts =
+	htgettoken = htgettoken:main


### PR DESCRIPTION
This PR refactors the `htgettoken` script into a Python module (importable as `import htgettoken`) with a command-line entry point built on the fly when the package is installed.