### PR TITLE
Fix --showbearerurl with --nobearertoken, and defer enabling http debugging

### DIFF
--- a/htgettoken.py
+++ b/htgettoken.py
@@ -738,9 +738,7 @@ def main():
                     log("Credkey from %s: %s" % (configfile, credkey))
 
     if (credkey is not None or options.nobearertoken) and not options.registerssh:
-        fullsecretpath = ""
-        if not options.nobearertoken:
-            fullsecretpath = secretpath.replace("%credkey", credkey)
+        fullsecretpath = secretpath.replace("%credkey", credkey)
 
         # Check to see if a valid vault token already exists and works by
         #   attempting to read a bearer token

--- a/htgettoken.py
+++ b/htgettoken.py
@@ -580,9 +580,6 @@ def main():
 
     parseargs(parser, envargs + sys.argv[1:])
 
-    if options.debug:
-        http.client.HTTPConnection.debuglevel = 5
-
     if options.optserver is not None:
         # read additional options from optserver
         optserver = options.optserver
@@ -657,6 +654,12 @@ def main():
         # switch log output to stdout if nothing else is using it
         global logfile
         logfile=sys.stdout
+        if options.debug:
+            log("Enabling HTTPConnection debugging")
+            # Unfortunately in urllib3 this only ever prints to stdout,
+            # so only enable the HTTPConnection debugging when not needing
+            # to parse stdout
+            http.client.HTTPConnection.debuglevel = 5
 
     if not options.nooidc and not sys.stdout.isatty() \
                 and not sys.stderr.isatty() and not sys.stdin.isatty():

--- a/htgettoken.spec
+++ b/htgettoken.spec
@@ -71,6 +71,7 @@ rm -rf $RPM_BUILD_ROOT
 # -- changelog
 
 %changelog
+# - Make --showbearerurl work properly in combination with --nobearertoken
 # - Replace use of m2crypto and pyOpenSSL with urllib3
 # - Replace use of pykerberos with gssapi
 # - Use standard Requires for Python modules instead of PyInstaller


### PR DESCRIPTION
This makes `--showbearerurl` work in combination with `--nobearertoken`, and defers enabling http debugging until after it is known whether or not stdout can be used for logging.