### PR TITLE
Send the output from httokendecode to stderr when there is no token

### DIFF
--- a/httokendecode
+++ b/httokendecode
@@ -106,7 +106,7 @@ else
 fi
 if [ -n "$TOKENFILE" ]; then
     if [ ! -e "$TOKENFILE" ]; then
-        echo "$TOKENFILE not found" 
+        echo "$TOKENFILE not found" >&2
         exit 1
     fi
     read TOKEN <$TOKENFILE


### PR DESCRIPTION
The output from httokendecode when there is no token should be sent to stderr. Otherwise piping the results to something expecting json produces confusing results