### PR TITLE
Handle complicated defaults with functions

### DIFF
--- a/htgettoken.py
+++ b/htgettoken.py
@@ -12,6 +12,16 @@
 #
 # Author: Dave Dykstra dwd@fnal.gov
 
+"""Get OIDC bearer tokens by interacting with Hashicorp vault.
+
+See the htgettoken manual page (`htgettoken(1)`) for more verbose details
+than are included by -h/--help.
+
+Note that the default arguments printed by -h/--help are influenced
+by both the ``$HTGETTOKENOPTS`` environment variable AND the
+information received from the -s/--optserver (if configured).
+"""
+
 from __future__ import print_function
 
 prog = "htgettoken"

--- a/htgettoken.py
+++ b/htgettoken.py
@@ -157,6 +157,19 @@ def elog(msg, e):
     log(msg + ': ' + expandexception(e))
 
 
+def default_web_open_command():
+    """Determine the sensible default for the --web-open-command option.
+    """
+    if os.getenv("SSH_CLIENT"):  # unsupported
+        return None
+    # otherwise use a sensible default if the platform is recognised
+    return {
+        "darwin": "open",
+        "linux": "xdg-open",
+        "win32": "start",
+    }.get(sys.platform)
+
+
 class vaulthost:
     """This is very similar to corresponding code in the HTCondor VaultCredmon.
 
@@ -612,8 +625,8 @@ def main():
                       defaults['capath'] + ']')
     parser.add_option("--web-open-command",
                       metavar="command",
-                      help="Command to execute to open a URL in a web browser " +
-                      '[default: "xdg-open" unless $SSH_CLIENT is set]')
+                      default=default_web_open_command(),
+                      help="Command to execute to open a URL in a web browser")
 
     # Change the default handler for SIGINT from raising a KeyboardInterrupt
     #  (which is ignored by urllib) to SIG_DFL (which exits)
@@ -716,16 +729,6 @@ def main():
         if options.verbose:
             log("Disabling oidc because running in the background")
         options.nooidc = True
-
-    if options.web_open_command is None:
-        sshclient = os.getenv("SSH_CLIENT")
-        if sshclient is None:
-            if sys.platform == 'darwin':
-                options.web_open_command = 'open'
-            else:
-                options.web_open_command = 'xdg-open'
-        else:
-            options.web_open_command = ""
 
     # Get and parse the vaultserver URL
     global vaultserver


### PR DESCRIPTION
This PR refactors the default-handling for `-o/--outfile` and `--web-open-command` into functions that are called directly when calling `add_option()`, rather than after-the-fact.

This has the upside that the `-h/--help` message now shows exactly what the default will be, rather than a statement of logic.

@DrDaveD, one feature that I removed here, is that if the user deliberately passes a string that contains `%uid`, e.g. via `-o ./bt_%uid`, that is no longer expanded. However, I have no idea if that is 'supported' formally. Happy to put that back in as requested.