### PR TITLE
Update to 1.18 (master)

### DIFF
--- a/htgettoken.py
+++ b/htgettoken.py
@@ -15,7 +15,7 @@
 from __future__ import print_function
 
 prog = "htgettoken"
-version = "1.17"
+version = "1.18"
 
 import os
 import sys

--- a/htgettoken.spec
+++ b/htgettoken.spec
@@ -2,7 +2,7 @@
 
 Summary: Get OIDC bearer tokens by interacting with Hashicorp vault
 Name: htgettoken
-Version: 1.17
+Version: 1.18
 Release: 1%{?dist}
 
 License: BSD-3-Clause
@@ -83,9 +83,10 @@ rm -rf $RPM_BUILD_ROOT
 # - Use wheels to build/install Python package, which simplified the entry
 #   points and improves (slightly) the metadata
 
-# For 1.18:
-# - Fix crash introduced in 1.17 when using --nobearertoken while the
-#   credkey is not known.
+* Wed May 24 2023 Dave Dykstra <dwd@fnal.gov> 1.18-1
+- Fix crash introduced in 1.17 when using --nobearertoken while the
+  credkey is not known.
+- Make source rpm buildable on el9.
 
 * Wed Mar 15 2023 Dave Dykstra <dwd@fnal.gov> 1.17-1
 - Fix the usage of getaddrinfo, which caused a fatal error on python3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = htgettoken
-version = 1.17
+version = 1.18
 author = Dave Dykstra
 author_email = dwd@fnal.gov
 license = BSD-3-Clause


### PR DESCRIPTION
This cherry-pick's the parts of  #78 still relevant (that is, just the version update) to the master branch.