### PR TITLE
Fix the background process' backup parent check & Allow --outfile option to specify a relative path (master)

### DIFF
--- a/htgettoken.py
+++ b/htgettoken.py
@@ -439,8 +439,10 @@ def writeTokenSafely(tokentype, token, outfile):
         except:
             pass
         try:
-            fd, path = tempfile.mkstemp(
-                prefix=os.path.dirname(outfile) + '/.' + prog)
+            dir=os.path.dirname(outfile)
+            if dir == '':
+                dir = '.'
+            fd, path = tempfile.mkstemp(prefix='.' + prog, dir=dir)
             handle = os.fdopen(fd, 'w')
         except Exception as e:
             efatal("failure creating file", e)

--- a/htgettoken.spec
+++ b/htgettoken.spec
@@ -92,6 +92,7 @@ rm -rf $RPM_BUILD_ROOT
 #  That is only a backup in case only the parent process is hard-killed,
 #  because normally the parent process kills the background process when
 #  the parent exits.
+#- Fix the `-o`/`--outfile` option to work with relative paths. 
 
 * Thu Aug 17 2023 Dave Dykstra <dwd@fnal.gov> 1.20-1
 - Update httokensh to by default set the minimum vault token time to live to

--- a/htgettoken.spec
+++ b/htgettoken.spec
@@ -87,6 +87,12 @@ rm -rf $RPM_BUILD_ROOT
 # - Use wheels to build/install Python package, which simplified the entry
 #   points and improves (slightly) the metadata
 
+
+#- Fix the httokensh background process's check for its parent process.
+#  That is only a backup in case only the parent process is hard-killed,
+#  because normally the parent process kills the background process when
+#  the parent exits.
+
 * Thu Aug 17 2023 Dave Dykstra <dwd@fnal.gov> 1.20-1
 - Update httokensh to by default set the minimum vault token time to live to
   6 days, and to make sure that the background refresh never gets a new vault

--- a/httokensh
+++ b/httokensh
@@ -136,16 +136,18 @@ set -m
 
 echo "Renewal log is at \$BEARER_TOKEN_FILE.log"
 {
+    # keep a copy of $PPID because it will change to 1 if parent dies
+    PARENTPID=$PPID
     echo htgettoken args are "${HTGETTOKENARGS[@]}"
     while true; do
         date
         echo "Renewal scheduled in $SLEEPSECS seconds"
         sleep $SLEEPSECS
         date
-        if kill -0 $PPID; then
+        if kill -0 $PARENTPID; then
             gettoken "exiting" 60
         else
-            echo "Parent process $PPID not running, exiting"
+            echo "Parent process $PARENTPID not running, exiting"
             exit 0
         fi
     done


### PR DESCRIPTION
Cherry-pick commits from #90 and #97 to the master branch.