### PR TITLE
Get credkey for ssh even with --nobearertoken

### DIFF
--- a/htgettoken.py
+++ b/htgettoken.py
@@ -771,7 +771,7 @@ def main():
 
     credkey = options.credkey
     configfile = None
-    if credkey is None and (not options.nobearertoken or options.showbearerurl):
+    if credkey is None and (not options.nobearertoken or options.showbearerurl or not options.nossh):
         # Look for saved credkey, needed for figuring out the vault secretpath
         configfile = options.configdir + '/credkey-' + options.issuer + '-' + options.role
         configfile = os.path.expanduser(configfile)


### PR DESCRIPTION
I had missed verifying `--nobearertoken` with ssh authentication in #99.  It needs the credkey.

- Fixes #94