### PR TITLE
Fix htdecodetoken to work with token files that do not end in a newline

### DIFF
--- a/htdecodetoken
+++ b/htdecodetoken
@@ -109,7 +109,8 @@ if [ -n "$TOKENFILE" ]; then
         echo "$TOKENFILE not found" >&2
         exit 1
     fi
-    read TOKEN <$TOKENFILE
+    # the -n is needed here for when there is no ending newline in the file
+    read TOKEN <$TOKENFILE || [ -n "$TOKEN" ]
 fi
 if [ -z "$TOKEN" ]; then
     echo "Token is empty" >&2

--- a/htgettoken.spec
+++ b/htgettoken.spec
@@ -80,6 +80,8 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+# - Fix htdecodetoken to work with token files that do not end in a newline.
+
 * Thu Jul 25 2024 Dave Dykstra <dwd@fnal.gov> 2.0-2
 - Fix broken httokendecode symlink.
 - Use python wheels to build/install on el9.  It didn't work on el8 so


### PR DESCRIPTION
- Fixes #108 