### PR TITLE
Support args in htgettoken.main()

### DIFF
--- a/htgettoken.spec
+++ b/htgettoken.spec
@@ -81,6 +81,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %changelog
 # - Fix htdecodetoken to work with token files that do not end in a newline.
+# - Support args in htgettoken.main() Python entry point.
 
 * Thu Jul 25 2024 Dave Dykstra <dwd@fnal.gov> 2.0-2
 - Fix broken httokendecode symlink.

--- a/htgettoken/__init__.py
+++ b/htgettoken/__init__.py
@@ -499,7 +499,7 @@ def ttl2secs(ttl, msg):
 
 
 ### htgettoken main ####
-def main():
+def main(args=None):
     global options
     usagestr = "usage: %prog [-h] [otheroptions]"
     parser = OptionParser(usage=usagestr, version=version, prog=prog)
@@ -630,8 +630,10 @@ def main():
     # look for default options in the environment
     envopts = os.getenv("HTGETTOKENOPTS", "")
     envargs = shlex.split(envopts, True)
+    if args is None:
+        args = sys.argv[1:]
 
-    parseargs(parser, envargs + sys.argv[1:])
+    parseargs(parser, envargs + list(args))
 
     if options.optserver is not None:
         # read additional options from optserver


### PR DESCRIPTION
This PR adds support for passing arguments directly to the `hgettoken.main()` python function, allowing users in Python sessions to control the behaviour of htgettoken without manipulating `sys.argv`.

This enables the following pure Python workflow for getting tokens without calls to `subprocess` or similar:

```python
import tempfile
from pathlib import Path
from htgettoken import main as htgettoken
from scitokens import SciToken

with tempfile.TemporaryDirectory() as tmpdir:
    path = Path(tmpdir) / "test.token"
    htgettoken([
        f"--outfile={path}",
        "--quiet",
    ])
    token = SciToken.deserialize(path.read_text().strip())
print(dict(token.claims()))
```